### PR TITLE
feat: 백스페이스 말고도 delete키로 삭제할수 있게 변경

### DIFF
--- a/src/app/painting/_component/_utils/switchTool.tsx
+++ b/src/app/painting/_component/_utils/switchTool.tsx
@@ -22,7 +22,7 @@ export const SwitchTool: React.FC<SwitchToolProps> = ({
       if (e.key === 'Alt') {
         canvas.isDrawingMode = false;
         Tool.panning.enable(canvas);
-      } else if (e.key === 'Backspace') {
+      } else if (e.key === 'Backspace' || e.key === 'delete') {
         const activeObject = canvas.getActiveObject();
         if (activeObject) {
           canvas.remove(activeObject);


### PR DESCRIPTION
## 연관된 이슈
- #76 

## 작업 내용
- 백스페이스버튼뿐만아니라 delete버튼을 눌러도 삭제가 될수있게 변경하였습니다.

## 작업 브랜치 이름
`76/feat: 백스페이스 말고도 delete키로 삭제할수 있게 변경`

## 리뷰 요구사항 (선택)
